### PR TITLE
Add production Docker-Compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,13 @@ Run the application in production mode
 3. Create the tables: `RAILS_ENV=production bin/rake db:migrate`
 4. Run the server: `RAILS_ENV=production bin/rails s`
 
+Run the full app through Docker-Compose for production
+------------------------------------------------------
+
+1. Fill the environment variables in `docker-compose.yml`
+2. Run the containers `docker-compose up`
+3. Access the website with `localhost:8080` or `yourdomain.net:8080`
+
 Run the test
 ------------
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,28 @@
+version: '3'
+services:
+  cnil-pia-back:
+    image: lrqdo/cnil-pia-back
+    restart: always
+    environment:
+      DATABASE_HOST: 'database'
+      DATABASE_USERNAME: 'postgres'
+      DATABASE_PASSWORD: 'somepassword'
+      SECRET_KEY_BASE: 'somesecret'
+    links:
+      - database
+    depends_on:
+      - database
+    ports:
+      - 3000:3000
+
+  cnil-pia-front:
+    image: lrqdo/cnil-pia-front
+    restart: always
+    ports:
+      - 0.0.0.0:8080:80
+
+  database:
+    restart: always
+    image: postgres:10.1
+    environment:
+      POSTGRES_PASSWORD: 'somepassword'


### PR DESCRIPTION
Hello,

There is already a Pull Request for a Docker Compose for development purpose https://github.com/LINCnil/pia-back/pull/12 but here is one used for production purpose.

Everything is automated from creating containers to setting up the database. A simple `docker-compose up` does everything and gives a running website : front-end, back-end and database.

However, you still have to add the back-end URL on the front-end interface as we don't see a way to automate it.

The Docker images are hosted on our company's Docker Hub and we can also provide you the Dockerfiles used to build them yourself. We just don't know where to put them.

Maybe this repository is not well suited for a Docker configuration, we could imagine having a special repository `pia-docker` ?