### PR TITLE
fix: update French and English instructions for back-end application setup and installation

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -12,21 +12,25 @@
     <div class="french">
       <h2>Français</h2>
       <p>
-        Vous avez mis en place avec succès l'application back office.<br>
-        Veuillez installer <a href="https://github.com/LINCnil/pia" target="_blank">l'application front office</a> pour continuer.<br>
-        Vous pouvez suivre <a href="https://github.com/LINCnil/pia/issues/77" target="_blank">ce runbook</a> pour une installation complète de l'application pia (front office) sur un serveur Ubuntu 17.10.
+        Vous avez configuré avec succès l'application back-end.<br>
+        Veuillez installer l'application <a href="https://github.com/LINCnil/pia" target="_blank">PIA (front-end)</a> pour continuer.<br>
+        Vous pouvez consulter le <a href="https://github.com/LINCnil/pia-back/wiki" target="_blank">wiki officiel</a> pour obtenir les instructions complètes d'installation de l'application PIA (front-end) sur un serveur Ubuntu.
       </p>
-      <p>Programme développé avec le framework RubyOnRails mettant à disposition une API RESTful à destination <strong>des outils <a href="https://github.com/LINCnil/pia" target="_blank">pia (front office)</a> et <a href="https://github.com/LINCnil/pia-app" target="_blank">pia-app</a>.</strong></p>
+      <p>
+        Ce programme est développé avec Ruby on Rails et fournit une API RESTful pour l'application <a href="https://github.com/LINCnil/pia" target="_blank">PIA (front-end)</a>.
+      </p>
     </div>
 
     <div class="english">
       <h2>English</h2>
       <p>
-        You have successfully setup the back-end application.<br>
-        Please, install <a href="https://github.com/LINCnil/pia" target="_blank">pia (front-end) application</a> to continue.<br>
-        You can follow <a href="https://github.com/LINCnil/pia/issues/77" target="_blank">this runbook</a> for a full installation of pia (front-end) application on a ubuntu 17.10 server.
+        You have successfully set up the back-end application.<br>
+        Please install the <a href="https://github.com/LINCnil/pia" target="_blank">PIA (front-end)</a> application to continue.<br>
+        You can follow the <a href="https://github.com/LINCnil/pia-back/wiki" target="_blank">official wiki</a> for full instructions on installing the PIA (front-end) application on an Ubuntu server.
       </p>
-      <p>Program developped with RubyOnRails providing a RESTful API for <strong><a href="https://github.com/LINCnil/pia" target="_blank">the pia (front-end)</a> and <a href="https://github.com/LINCnil/pia-app" target="_blank">pia-app</a> applications.</strong></p>
+      <p>
+        This program is developed with Ruby on Rails and provides a RESTful API for the <a href="https://github.com/LINCnil/pia" target="_blank">PIA (front-end)</a> application.
+      </p>
     </div>
   </body>
 </html>


### PR DESCRIPTION
This pull request updates the French and English instructions on the `public/index.html` page to provide clearer guidance and more accurate information for users setting up the application. The instructions now reference the official wiki for installation steps and clarify the description of the back-end's role.

**User documentation improvements:**

* Updated French and English setup instructions to reference the official wiki (`pia-back/wiki`) for up-to-date installation guidance instead of an outdated runbook or issue.
* Clarified that the back-end is developed with Ruby on Rails and provides a RESTful API specifically for the PIA (front-end) application, removing references to the deprecated `pia-app`.